### PR TITLE
libigl as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/libigl"]
+	path = extern/libigl
+	url = https://github.com/libigl/libigl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ add_definitions(-DGAUSS_DATA_DIR=${PROJECT_SOURCE_DIR}/data)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 #libigl include directory
-set(LIBIGL_INCLUDE_PATH ${PROJECT_SOURCE_DIR}/../libigl/include CACHE FILEPATH "Root include directory for libigl")
+set(LIBIGL_INCLUDE_PATH ${PROJECT_SOURCE_DIR}/extern/libigl/include CACHE FILEPATH "Root include directory for libigl")
 
 #Eigen
 find_package(Eigen3 REQUIRED)

--- a/InstallGAUSS_OSX.sh
+++ b/InstallGAUSS_OSX.sh
@@ -15,8 +15,6 @@ sudo hdiutil attach -noverify ./qt-opensource-mac-x64-5.9.0.dmg
 mkdir ./build
 cd ./build
 
-echo "Installing LibIGL from https://github.com/libigl/libigl"
-git clone --recursive https://github.com/libigl/libigl.git ./libigl
 
 echo "Building make files (this can fail if homebrew CMake version is wrong)"
 cmake .. -DCMAKE_PREFIX_PATH=~/Qt5.9.0/5.9/clang_64/lib/cmake -DLIBIGL_INCLUDE_PATH=./libigl/include -DEigen4_DIR=/usr/local/Cellar/eigen/3.3.4/include/eigen3 -DCMAKE_BUILD_TYPE=Release

--- a/InstallGAUSS_Ubuntu.sh
+++ b/InstallGAUSS_Ubuntu.sh
@@ -17,10 +17,8 @@ sudo apt-get install libglu1-mesa-dev -y
 sudo apt-get install libfontconfig1
 sudo apt-get install libeigen3-dev
 
-echo "Install libIGL"
 mkdir build
 cd build
-git clone --recursive https://github.com/libigl/libigl.git
 
 echo "Compile GAUSS"
 cmake .. -DCMAKE_PREFIX_PATH=/opt/Qt5.9.0/5.9/gcc_64/lib/cmake -DLIBIGL_INCLUDE_PATH=./libigl/include -DEigen3_DIR=/usr/include/eigen3 -DCMAKE_BUILD_TYPE=Release

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ OSX (el capitan)/Ubuntu (14.04): [![Build Status](https://travis-ci.org/dilevin/
 5. OPTIONAL: Spectra Eigenproblem Solver (https://spectralib.org)
 
 ### "Easy" Install Scripts ###
+
+Clone this repository with 
+```bash
+git clone --recursive https://github.com/dilevin/GAUSS.git
+```
+
 #### Install Instructions OS X (Basic install, no bells or whistles) ####
 1. Install Homebrew (https://brew.sh)
 2. At command line: chmod a+x ./InstallGAUSS_OSX.sh

--- a/config.cmake
+++ b/config.cmake
@@ -6,7 +6,7 @@
 
 
 ### libigl
-set(LIBIGL_INCLUDE_PATH "../libigl/include" CACHE FILEPATH "Root include directory for libigl")
+set(LIBIGL_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/extern/libigl/include" CACHE FILEPATH "Root include directory for libigl")
 
 
 ### OpenMP config


### PR DESCRIPTION
currently libigl is pulled via install scripts when it is easily be pulled with git submodules.
these patches change LIBIGL_INCLUDE_PATH, remove libigl pulls in install scripts, and updated the README.md to point out how to clone the library for submodules